### PR TITLE
Add Core network

### DIFF
--- a/hardhat/hardhat.config.ts
+++ b/hardhat/hardhat.config.ts
@@ -16,6 +16,10 @@ module.exports = {
     avalanche: {
       url: `https://api.avax.network/ext/bc/C/rpc`,
       accounts: [process.env.PRIVATE_KEY]
+    },
+    core: {
+      url: `https://rpc.coredao.org/`,
+      accounts: [process.env.PRIVATE_KEY]
     }
   }
 };


### PR DESCRIPTION
Adds Core network to Hardhat config so users can easily transfer to Core network